### PR TITLE
Improve keyword highlights

### DIFF
--- a/languages/powershell/highlights.scm
+++ b/languages/powershell/highlights.scm
@@ -1,35 +1,49 @@
-"param" @keyword
-"dynamicparam" @keyword
-"begin" @keyword
-"process" @keyword
-"end" @keyword
-"if" @keyword
-"elseif" @keyword
-"else" @keyword
-"switch" @keyword
-"foreach" @keyword
-"for" @keyword
-"while" @keyword
-"do" @keyword
-"until" @keyword
-"function" @keyword
-"filter" @keyword
-"workflow" @keyword
-"break" @keyword
-"continue" @keyword
-"throw" @keyword
-"return" @keyword
-"exit" @keyword
-"trap" @keyword
-"try" @keyword
-"catch" @keyword
-"finally" @keyword
-"data" @keyword
-"inlinescript" @keyword
-"parallel" @keyword
-"sequence" @keyword
-"class" @keyword
-"enum" @keyword
+[
+  "begin"
+  "break"
+  "catch"
+  "class"
+  "clean"
+  "continue"
+  "data"
+  "define"
+  "do"
+  "dynamicparam"
+  "else"
+  "elseif"
+  "end"
+  "enum"
+  "exit"
+  "filter"
+  "finally"
+  "for"
+  "foreach"
+  "from"
+  "function"
+  "hidden"
+  "if"
+  "in"
+  "param"
+  "process"
+  "return"
+  "static"
+  "switch"
+  "throw"
+  "trap"
+  "try"
+  "until"
+  "using"
+  "var"
+  "while"
+] @keyword
+
+; Powershell Workflows
+[
+  "inlinescript",
+  "parallel",
+  "sequence",
+  "workflow"
+] @keyword
 
 "-as" @operator
 "-ccontains" @operator
@@ -97,7 +111,10 @@
 "-not" @operator
 
 
-";" @delimiter
+[
+  ","
+  ";"
+] @punctuation.delimiter
 
 
 (string_literal) @string


### PR DESCRIPTION
https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_language_keywords?view=powershell-7.4


- Also fixed delimiter highlights 
https://github.com/zed-industries/zed/blob/0fd50302979539fbcb00cac7b29fd9bfe434b4f5/docs/src/extensions/languages.md?plain=1#L117