### PR TITLE
Zed PowerShell v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "powershell"
-version = "0.3.0-dev"
+version = "0.3.0"
 dependencies = [
  "zed_extension_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "powershell"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [lib]

--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "powershell"
 name = "PowerShell"
-version = "0.2.0"
+version = "0.3.0"
 schema_version = 1
 authors = ["Thanabodee Charoenpiriyakij <wingyminus@gmail.com>"]
 description = "PowerShell support"


### PR DESCRIPTION
@wingyplus Would you be willing to cut a release?
The current version in the Zed Extension store does not work with `powershell-es` but main does.

Merge after: https://github.com/wingyplus/zed-powershell/pull/11

Includes:
- https://github.com/wingyplus/zed-powershell/pull/7
- https://github.com/wingyplus/zed-powershell/pull/11
