### PR TITLE
Do not unwrap to return a more reasonable error

### DIFF
--- a/src/powershell.rs
+++ b/src/powershell.rs
@@ -23,7 +23,7 @@ impl zed::Extension for PowerShellExtension {
         language_server_id: &zed_extension_api::LanguageServerId,
         worktree: &zed_extension_api::Worktree,
     ) -> zed_extension_api::Result<zed_extension_api::Command> {
-        let pwsh_bin = PowerShellExtension::powershell_binary_path(self, worktree).unwrap();
+        let pwsh_bin = PowerShellExtension::powershell_binary_path(self, worktree)?;
 
         let bundle_path = self
             .language_server_path(language_server_id)


### PR DESCRIPTION
Unfortunately, this still shows an error in the status for mac users that have installed the extension but do not have powershell.