### PR TITLE
Update `zed_extension_api` to fix PowerShell LS not starting on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ path = "src/powershell.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.2.0"
+zed_extension_api = "0.7.0"


### PR DESCRIPTION
Fixes issue #16.
Supersedes PR #18. 